### PR TITLE
Fix /wp added to sites admin url when multisite is not a subdomain install

### DIFF
--- a/src/URLFixer.php
+++ b/src/URLFixer.php
@@ -42,10 +42,8 @@ class URLFixer
      */
     public function fixSiteURL($url)
     {
-        if (is_main_site() || is_subdomain_install()) {
-            if (substr($url, -3) !== '/wp') {
-                $url .= '/wp';
-            }
+        if (substr($url, -3) !== '/wp' && (is_main_site() || is_subdomain_install())) {
+            $url .= '/wp';
         }
         return $url;
     }

--- a/src/URLFixer.php
+++ b/src/URLFixer.php
@@ -42,7 +42,7 @@ class URLFixer
      */
     public function fixSiteURL($url)
     {
-        if(is_main_site() || is_subdomain_install()) {
+        if (is_main_site() || is_subdomain_install()) {
             if (substr($url, -3) !== '/wp') {
                 $url .= '/wp';
             }

--- a/src/URLFixer.php
+++ b/src/URLFixer.php
@@ -42,8 +42,10 @@ class URLFixer
      */
     public function fixSiteURL($url)
     {
-        if (substr($url, -3) !== '/wp') {
-            $url .= '/wp';
+        if(is_main_site() || is_subdomain_install()) {
+            if (substr($url, -3) !== '/wp') {
+                $url .= '/wp';
+            }
         }
         return $url;
     }


### PR DESCRIPTION
Proposed fix for https://github.com/roots/multisite-url-fixer/issues/1

This conditional won't append /wp to admin url when not a subdomain install and not the main site. I haven't tested it enough, but it seems to work. I will keep testing on my current project.